### PR TITLE
fix: add missing vite source aliases for transitive @pen/* workspace deps

### DIFF
--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -8,15 +8,19 @@
     "types": ["vite/client"],
     "baseUrl": ".",
     "paths": {
+      "@pen/assets-memory": ["../packages/tooling/assets-memory/src/index.ts"],
       "@pen/ai": ["../packages/extensions/ai/src/index.ts"],
       "@pen/ai-autocomplete": ["../packages/extensions/ai-autocomplete/src/index.ts"],
       "@pen/ai-skills": ["../packages/extensions/ai-skills/src/index.ts"],
       "@pen/ai-suggestions": ["../packages/extensions/ai-suggestions/src/index.ts"],
       "@pen/ai-tools": ["../packages/extensions/ai-tools/src/index.ts"],
+      "@pen/content-ops": ["../packages/shared/content-ops/src/index.ts"],
       "@pen/core": ["../packages/core/src/index.ts"],
       "@pen/crdt-yjs": ["../packages/crdt/yjs/src/index.ts"],
+      "@pen/dom": ["../packages/rendering/dom/src/index.ts"],
       "@pen/database": ["../packages/extensions/database/src/index.ts"],
       "@pen/export-html": ["../packages/extensions/export-html/src/index.ts"],
+      "@pen/export-json": ["../packages/extensions/export-json/src/index.ts"],
       "@pen/export-markdown": ["../packages/extensions/export-markdown/src/index.ts"],
       "@pen/import-html": ["../packages/extensions/import-html/src/index.ts"],
       "@pen/import-markdown": ["../packages/extensions/import-markdown/src/index.ts"],
@@ -27,7 +31,11 @@
       "@pen/schema-default": ["../packages/schema/default/src/index.ts"],
       "@pen/search": ["../packages/extensions/search/src/index.ts"],
       "@pen/shortcuts": ["../packages/extensions/shortcuts/src/index.ts"],
-      "@pen/types": ["../packages/types/src/index.ts"]
+      "@pen/types": ["../packages/types/src/index.ts"],
+      "@pen/markdown-serialization": ["../packages/shared/markdown-serialization/src/index.ts"],
+      "@pen/undo": ["../packages/extensions/undo/src/index.ts"],
+      "@pen/document-ops": ["../packages/extensions/document-ops/src/index.ts"],
+      "@pen/delta-stream": ["../packages/extensions/delta-stream/src/index.ts"]
     }
   },
   "include": ["src"]

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -65,6 +65,19 @@ const PEN_SOURCE_ALIASES = {
 	"@pen/shortcuts": fileURLToPath(
 		new URL("../packages/extensions/shortcuts/src/index.ts", import.meta.url),
 	),
+	"@pen/content-ops": fileURLToPath(
+		new URL("../packages/shared/content-ops/src/index.ts", import.meta.url),
+	),
+	"@pen/dom": fileURLToPath(new URL("../packages/rendering/dom/src", import.meta.url)),
+	"@pen/history": fileURLToPath(
+		new URL("../packages/extensions/history/src/index.ts", import.meta.url),
+	),
+	"@pen/markdown-serialization": fileURLToPath(
+		new URL("../packages/shared/markdown-serialization/src/index.ts", import.meta.url),
+	),
+	"@pen/assets-memory": fileURLToPath(
+		new URL("../packages/tooling/assets-memory/src/index.ts", import.meta.url)
+	),
 	"@pen/types": fileURLToPath(new URL("../packages/types/src/index.ts", import.meta.url)),
 	"@pen/undo": fileURLToPath(
 		new URL("../packages/extensions/undo/src/index.ts", import.meta.url),


### PR DESCRIPTION
`pnpm dev` fails because several `@pen/*` packages aliased to source in `vite.config.ts` import other local packages that aren't aliased, causing vite to look for a non-existent `dist/`. Added the four missing aliases for transitive workspace dependencies.

Post adding the missing alias paths, the local dev server is working fine. And able to see the UI at `http://localhost:5174`. 

### Reproduction

To reproduce the issue, run `npm run clean`. Which clears out all the existing `node_modules` and `build` files. And then do a fresh install and `npm run dev`. If the builds are already ran ones without this change, the dist persist from previous builds. So on clean install and dev builds seems to re-trigger the bug.