### PR TITLE
fix: improve navigation between slash comand list items

### DIFF
--- a/packages/rendering/react/src/primitives/slash-menu/list.tsx
+++ b/packages/rendering/react/src/primitives/slash-menu/list.tsx
@@ -3,6 +3,7 @@ import { useSlashMenuContext } from "./root";
 import { renderAsChild, type AsChildProps } from "../../utils/asChild";
 import { SlashMenuGroup } from "./group";
 import { SlashMenuItem } from "./item";
+import { buildItemGroups } from "./utils";
 
 export interface SlashMenuListProps extends AsChildProps {
 	ref?: React.Ref<HTMLElement>;
@@ -23,36 +24,28 @@ export function SlashMenuList(props: SlashMenuListProps) {
 	if (hasManualChildren) {
 		content = children;
 	} else {
-		const groups = new Map<string, typeof items>();
-		for (const item of items) {
-			const group = item.display.group ?? "Other";
-			const existing = groups.get(group) ?? [];
-			existing.push(item);
-			groups.set(group, existing);
-		}
+		const groups = buildItemGroups(items);
 
 		let globalIndex = 0;
-		const groupElements = Array.from(groups.entries()).map(
-			([group, groupItems]) => {
-				const itemElements = groupItems.map((item) => {
-					const idx = globalIndex++;
-					return (
-						<SlashMenuItem
-							key={item.type}
-							blockType={item.type}
-							index={idx}
-						>
-							{item.display.title}
-						</SlashMenuItem>
-					);
-				});
+		const groupElements = groups.map(({ group, items: groupItems }) => {
+			const itemElements = groupItems.map((item) => {
+				const idx = globalIndex++;
 				return (
-					<SlashMenuGroup key={group} heading={group}>
-						{itemElements}
-					</SlashMenuGroup>
+					<SlashMenuItem
+						key={item.type}
+						blockType={item.type}
+						index={idx}
+					>
+						{item.display.title}
+					</SlashMenuItem>
 				);
-			},
-		);
+			});
+			return (
+				<SlashMenuGroup key={group} heading={group}>
+					{itemElements}
+				</SlashMenuGroup>
+			);
+		});
 
 		content = groupElements;
 	}

--- a/packages/rendering/react/src/primitives/slash-menu/root.tsx
+++ b/packages/rendering/react/src/primitives/slash-menu/root.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../hooks/useSlashMenu";
 import { renderAsChild, type AsChildProps } from "../../utils/asChild";
 import { isDevelopmentEnvironment } from "../../utils/environment";
+import { buildItemGroups } from "./utils";
 
 export type SlashMenuContextValue = SlashMenuState &
 	SlashMenuActions & {
@@ -87,6 +88,41 @@ type SlashMenuRootContentProps = Omit<
 	editor?: Editor;
 };
 
+function navigateInGroup(
+	items: ReadonlyArray<{ display: { group?: string } }>,
+	selectedIndex: number,
+	direction: -1 | 1,
+): number {
+	const len = items.length;
+	if (len === 0) {
+		return 0;
+	}
+
+	const groups = buildItemGroups(items);
+	if (groups.length <= 1) {
+		return (selectedIndex + direction + len) % len;
+	}
+
+	for (let g = 0; g < groups.length; g++) {
+		const { indices } = groups[g];
+		const pos = indices.indexOf(selectedIndex);
+		if (pos !== -1) {
+			const nextPos = pos + direction;
+			if (nextPos >= 0 && nextPos < indices.length) {
+				return indices[nextPos];
+			}
+			const nextGroup =
+				(g + direction + groups.length) % groups.length;
+			const { indices: nextIndices } = groups[nextGroup];
+			return direction === 1
+				? nextIndices[0]
+				: nextIndices[nextIndices.length - 1];
+		}
+	}
+
+	return (selectedIndex + direction + len) % len;
+}
+
 function SlashMenuRootContent(props: SlashMenuRootContentProps) {
 	const {
 		controller,
@@ -132,11 +168,11 @@ function SlashMenuRootContent(props: SlashMenuRootContentProps) {
 				case "ArrowDown": {
 					event.preventDefault();
 					event.stopPropagation();
-					const nextIndex =
-						currentState.items.length === 0
-							? 0
-							: (currentState.selectedIndex + 1) %
-								currentState.items.length;
+					const nextIndex = navigateInGroup(
+						currentState.items,
+						currentState.selectedIndex,
+						1,
+					);
 					wrappedStateRef.current = {
 						...currentState,
 						selectedIndex: nextIndex,
@@ -147,13 +183,11 @@ function SlashMenuRootContent(props: SlashMenuRootContentProps) {
 				case "ArrowUp": {
 					event.preventDefault();
 					event.stopPropagation();
-					const nextIndex =
-						currentState.items.length === 0
-							? 0
-							: (currentState.selectedIndex -
-									1 +
-									currentState.items.length) %
-								currentState.items.length;
+					const nextIndex = navigateInGroup(
+						currentState.items,
+						currentState.selectedIndex,
+						-1,
+					);
 					wrappedStateRef.current = {
 						...currentState,
 						selectedIndex: nextIndex,

--- a/packages/rendering/react/src/primitives/slash-menu/utils.ts
+++ b/packages/rendering/react/src/primitives/slash-menu/utils.ts
@@ -1,0 +1,30 @@
+export interface ItemGroup<TItem> {
+	group: string;
+	items: TItem[];
+	indices: number[];
+}
+
+export function buildItemGroups<TItem extends { display: { group?: string } }>(
+	items: readonly TItem[],
+): ItemGroup<TItem>[] {
+	const map = new Map<
+		string,
+		{ items: TItem[]; indices: number[] }
+	>();
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i];
+		const group = item.display.group ?? "Other";
+		let entry = map.get(group);
+		if (!entry) {
+			entry = { items: [], indices: [] };
+			map.set(group, entry);
+		}
+		entry.items.push(item);
+		entry.indices.push(i);
+	}
+	return Array.from(map.entries()).map(([group, data]) => ({
+		group,
+		items: data.items,
+		indices: data.indices,
+	}));
+}


### PR DESCRIPTION
When navigating between the slash commands. The highlighter jumps between groups. As it goes by indexes, and groups shuffle them around.

### Current Behaviour
<img width="2700" height="1714" alt="navigation-bug" src="https://github.com/user-attachments/assets/72bd5f02-e9c6-49df-a3d3-391314b442f7" />

### Fix
<img width="2700" height="1714" alt="navigation-fix" src="https://github.com/user-attachments/assets/6d0f22c8-919e-4bdf-b4a4-2a156f5a6699" />
