### PR TITLE
fix: add key for `PenEditor` component from `@input/pen-react`

### DIFF
--- a/packages/rendering/react/src/penEditor.tsx
+++ b/packages/rendering/react/src/penEditor.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import type { Editor } from "@input/pen-types";
 import { EditorRoot, type EditorRootProps } from "./primitives/editor/root";
 import {
 	EditorContent,
@@ -32,6 +31,7 @@ export function PenEditor(props: PenEditorProps) {
 
 	return (
 		<EditorRoot
+			key={editor.internals.viewId}
 			editor={editor}
 			readonly={readonly}
 			importers={importers}


### PR DESCRIPTION
## Summary

<img width="1539" height="284" alt="Screenshot 2026-08-27 at 9 55 07 PM" src="https://github.com/user-attachments/assets/39080b99-0ce1-4336-b2dc-f318530b6d97" />

`@input/pen-react`'s `PenEditor` is missing `key={editor.internals.viewId}` on its `EditorRoot`, so it doesn't remount when the editor swaps.
`EditorPane` passes it when being used in playground.
https://github.com/input-systems/pen/blob/78a5770f298b599ca58a9ac693be7e67f9dfe326/playground/src/editor/EditorPane.tsx#L55-L60

## Reproduction

- Run `pnpm dev`
- Navigate to the port where the reac example is running.

## Checklist

- [x] `pnpm verify` passes locally (runs the same gates CI does, minus the browser suites)
- [ ] Changeset (`pnpm changeset`) Haven' ran this, as the package is not published to npm yet.


Btw, the re-design is so good 🚀 
