### PR TITLE
Unblock the 0.1.1 release train

### DIFF
--- a/.changeset/lucky-tables-greet.md
+++ b/.changeset/lucky-tables-greet.md
@@ -1,6 +1,6 @@
 ---
-"@input/pen-multiplayer": minor
-"@input/pen-react": minor
+"@input/pen-multiplayer": patch
+"@input/pen-react": patch
 "@input/pen-dom": patch
 ---
 

--- a/.size-limit.baseline.json
+++ b/.size-limit.baseline.json
@@ -117,9 +117,9 @@
     {
       "name": "@input/pen-multiplayer",
       "path": "packages/extensions/multiplayer/dist/index.mjs",
-      "baselineBytes": 43166,
-      "limitBytes": 43166,
-      "note": "Re-recorded baseline 2026-08-21. Path .js \u2192 .mjs. Bytes: awareness validation / presence bounds. 20968 \u2192 43166."
+      "baselineBytes": 51574,
+      "limitBytes": 51574,
+      "note": "Re-recorded baseline 2026-08-27. Cell-selection presence (a `{ kind: \"cell\" }` awareness member, COL2 grid validation, and resolve) plus a declared `streaming` awareness key so a peer's AI run is visible. 43166 \u2192 51574. Byte total reproduced across two clean rebuilds."
     },
     {
       "name": "@input/pen",


### PR DESCRIPTION
## Summary
- Re-record `@input/pen-multiplayer` size-limit from 43166 → 51574 B (cell-selection presence and the declared `streaming` awareness key). Two clean rebuilds reproduced 51574. This is what has been failing Release CI on `main` and blocking the Version Packages PR.
- Downgrade the table-cell presence changeset from `minor` to `patch` so the train is **0.1.1**. A `minor` bump of `@input/pen-multiplayer` (an optional peer of `@input/pen-react`) would promote the whole fixed group to 1.0.0, which API7 rejects until 1.0.

## Test plan
- [x] `node scripts/size-limit.mjs` passes locally
- [x] `@input/pen-multiplayer` dist is 51574 B on two rebuilds
- [ ] Release workflow on `main` after merge opens a Version Packages PR at 0.1.1
- [ ] Merge that PR; `changeset publish` ships `@input/pen@0.1.1`


Made with [Cursor](https://cursor.com)