### PR TITLE
Playground hosting

### DIFF
--- a/.changeset/strict-adults-open.md
+++ b/.changeset/strict-adults-open.md
@@ -1,0 +1,27 @@
+---
+"@input/pen": patch
+"@input/pen-ai": patch
+"@input/pen-assets": patch
+"@input/pen-autoformat": patch
+"@input/pen-bench": patch
+"@input/pen-core": patch
+"@input/pen-dom": patch
+"@input/pen-ingest": patch
+"@input/pen-interop": patch
+"@input/pen-markdown": patch
+"@input/pen-multiplayer": patch
+"@input/pen-react": patch
+"@input/pen-schema": patch
+"@input/pen-search": patch
+"@input/pen-shortcuts": patch
+"@input/pen-snapshots": patch
+"@input/pen-test": patch
+"@input/pen-tools": patch
+"@input/pen-transport": patch
+"@input/pen-types": patch
+"@input/pen-undo": patch
+"@input/pen-vue": patch
+"@input/pen-yjs": patch
+---
+
+Updated playground hosting & docs

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 https://pen-playground.input.so/
 
-<img width="1543" alt="Web preview of the Pen playground" src="https://input-pr-z1wpxj.s3.us-west-2.amazonaws.com/pen/pen-playground-preview.png" />
+<img width="1543" alt="Web preview of the Pen playground" src="https://input-pr-z1wpxj.s3.us-west-2.amazonaws.com/pen/playground-preview.png" />
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 
 **Runs without a DOM.** The same runtime works in Node, so agents, servers, and pipelines edit documents through the API the editor uses.
 
+## Try it out
+
+https://pen-playground.input.so
+
+<img width="1543" alt="Web preview of the Pen playground" src="https://input-pr-z1wpxj.s3.us-west-2.amazonaws.com/pen/pen-playground-preview.png" />
+
 ## Quick Start
 
 Every host follows the same two steps: build an editor, then mount it. `createEditor()` from `@input/pen` comes with the batteries preset applied; the default schema, undo, formatting shortcuts, document tools, and the streaming writer. The React and Vue hooks own the editor's lifetime themselves, so they take the preset as an option instead.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Try it out
 
-https://pen-playground.input.so
+https://pen-playground.input.so/
 
 <img width="1543" alt="Web preview of the Pen playground" src="https://input-pr-z1wpxj.s3.us-west-2.amazonaws.com/pen/pen-playground-preview.png" />
 
@@ -348,7 +348,7 @@ Expanded field-editor mode and table-cell editing always use contenteditable, ev
 
 - **[Documentation](https://input-systems.github.io/pen/)**: getting started per host, core concepts, selection, extensions, commands, collaboration, AI, import and export, security, and accessibility.
 - **Examples**: minimal Vite apps at [`examples/react`](examples/react), [`examples/vue`](examples/vue), and [`examples/vanilla`](examples/vanilla). Each is a workspace member consuming the built packages, so `pnpm build` once and then `pnpm --filter @input/pen-example-react dev`. CI mounts each one and types into it. A drifted quickstart fails the build.
-- **[Playground](https://pen-playground.input-systems.workers.dev)**: the reference app (editor, AI agent, document inspector, and live collaboration). Hosted on Cloudflare. Locally, `pnpm --dir playground run dev` after `pnpm build`. It is the host for `pnpm test:e2e`, not a starter template.
+- **[Playground](https://pen-playground.input.so/)**: the reference app (editor, AI agent, document inspector, and live collaboration). Hosted on Cloudflare. Locally, `pnpm --dir playground run dev` after `pnpm build`. It is the host for `pnpm test:e2e`, not a starter template.
 
 ## Development
 

--- a/packages/docs/src/pages/GettingStarted.tsx
+++ b/packages/docs/src/pages/GettingStarted.tsx
@@ -62,7 +62,7 @@ export function GettingStartedPage() {
 			<p>
 				License and distribution are stated in the repository root
 				README. The{" "}
-				<a href="https://pen-playground.input-systems.workers.dev">
+				<a href="https://pen-playground.input.so/">
 					playground
 				</a>{" "}
 				is the try-it host: editor, scripted agent, and live rooms.

--- a/playground/README.md
+++ b/playground/README.md
@@ -23,7 +23,7 @@ anything.
 
 The same app ships as a Cloudflare Worker: static UI, `POST /api/chat`, and
 one Durable Object per Yjs room at `/collaboration/<room>`. Live at
-[pen-playground.input-systems.workers.dev](https://pen-playground.input-systems.workers.dev).
+[pen-playground.input.so](https://pen-playground.input.so/).
 Build the workspace packages first, then:
 
 ```bash

--- a/spec/packages/playground.md
+++ b/spec/packages/playground.md
@@ -16,7 +16,7 @@ It stays narrow on purpose. A surface is added here only when a first-time embed
 - Workspace scripts: `build`, `dev`, `dev:e2e`, `deploy`, `test`, `typecheck`, `lint`
 - Client entry: `src/main.tsx` mounts `src/App.tsx`, a three-pane shell over one `Editor`.
 - Server entry: `server/aiPlugin.ts` and `server/collaborationPlugin.ts`, Vite middleware that serves `POST /api/chat` and the Yjs websocket at `/collaboration`. There is no second process to start.
-- Hosted entry: `worker/index.ts` is the Cloudflare Worker. It serves the Vite `dist/` as a single-page app, the same `POST /api/chat`, and the same `/collaboration/<room>` y-websocket protocol on a Durable Object per room (`worker/yjsRoom.ts`). Live at `https://pen-playground.input-systems.workers.dev`. `pnpm --dir playground run deploy` (and the Playground ship job on `main`) publishes it.
+- Hosted entry: `worker/index.ts` is the Cloudflare Worker. It serves the Vite `dist/` as a single-page app, the same `POST /api/chat`, and the same `/collaboration/<room>` y-websocket protocol on a Durable Object per room (`worker/yjsRoom.ts`). Live at `https://pen-playground.input.so/`. `pnpm --dir playground run deploy` (and the Playground ship job on `main`) publishes it.
 
 ## Dependencies And Boundaries
 


### PR DESCRIPTION
### Description

- Introduced a new section in README.md for users to try out the Pen playground.
- Included a link to the playground and an image preview to enhance user engagement and provide a visual reference.

These updates improve docs by making it easier to access and visualize the project.

→ [updated readme preview](https://github.com/input-systems/pen/blob/5ec34a15051c9e4dde7057ac8efb081aee13b843/README.md)
→ https://pen-playground.input.so
