### PR TITLE
Fix focus sink showing a focus ring on block and cell selection

### DIFF
--- a/.changeset/purple-pants-join.md
+++ b/.changeset/purple-pants-join.md
@@ -1,0 +1,5 @@
+---
+"@input/pen-dom": patch
+---
+
+Fix the a11y focus sink drawing a visible focus ring when a block or cell selection is active.

--- a/packages/rendering/dom/src/a11y/focusSink.ts
+++ b/packages/rendering/dom/src/a11y/focusSink.ts
@@ -78,6 +78,10 @@ function hideSink(element: HTMLElement): void {
 	element.tabIndex = -1;
 	element.removeAttribute("role");
 	element.removeAttribute("aria-label");
+	// Suppress :focus-visible on a non-interactive AT-management element.
+	// Host global styles (e.g. :focus-visible { outline: ... }) leak into
+	// the sink when it is programmatically focused for block/cell selection.
+	element.style.outline = "none";
 }
 
 function revealSink(element: HTMLElement, selection: FocusSinkReveal): void {


### PR DESCRIPTION
Hey, beforehand. Let me know, if i am creating noise around the repo 😅. I was just testing things around, and making suggestions / trying to fix stuff.

## Summary
https://github.com/user-attachments/assets/c05a6214-cd0e-4ff9-b567-99d5d0a66b97

Fix focus sink showing a focus ring on block and cell selection. Select a block, or click a table cell, and a thin grey line (~1.5px) shows up at the bottom of the editor. Turns out it's a focus ring on the focus sink — the hidden <div> Pen uses purely for screen readers.

```html
<div data-pen-focus-sink="" tabindex="0" role="grid" aria-label="1 by 1 cells selected"></div>
```
### What's happening

Pen keeps this sink so AT gets told `"1 by 1 cells selected"` on selection. `revealSink` makes it focusable (tabIndex = 0, drops aria-hidden), then `element.focus()` runs so the screen reader picks it up.

The problem is the sink was never visually `hidden`. When not in use it just relies on `aria-hidden="true"`, which means nothing on screen. So the moment focus lands on it, the browser applies `:focus-visible` and any host CSS like `:focus-visible { outline: ... }` paints a ring around it.

The announcer (role="status") avoids this by clip-hiding itself — the sink never got the same treatment.

I confirmed it also shows up from a plain mouse click, not just keyboard, since browsers treat any programmatically-focused non-interactive element as "show the ring" regardless of input modality. Same bug exists for block selection, tables just make it easier to spot.

From the recording, you can see that when we are editing the table cell. The `:focus-visible` gets triggered. And we can see the outline being applied from the `token.css` file all the time.

### The fix
Apply `outline: none` inline inside hideSink, so it's set at style construction and stays through `revealSink` (which never clears it).

## Spec
This bugfix doesn't touch the spec, but it does expose a gap in AX5 — it says every `outline: none` needs a `:focus-visible` replacement, which never doesn't align for AT-management nodes like the focus sink. Should i add a caveat for this case for the AX5 rule ?


## Checklist

- [x] `pnpm verify` passes locally (runs the same gates CI does, minus the browser suites)
- [x] Changeset (`pnpm changeset`) if a published package's behavior or public API changed
- [x] Spec rule IDs listed above; tests that claim those IDs include the ID in the test name
- [ ] No new slots (`*_SLOT` / `setSlot` outside the adapter)
- [ ] No pipeline bypass: durable writes go through `editor.apply` (or `openTextStream`); no direct `Y.Text` / `Y.Map` writes or `adapter.transact` outside `@input/pen-core`
